### PR TITLE
Add php-7.4 test on Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,17 @@ matrix:
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
         - php: 7.3
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
+        - php: 7.4
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
 
           # Test the latest stable release
         - php: 7.2
         - php: 7.3
+        - php: 7.4
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text --coverage-clover=coverage.xml"
 
           # Latest commit to master
-        - php: 7.3
+        - php: 7.4
           env: STABILITY="dev"
 
     allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "php": "^7.2"
     },
     "require-dev": {
         "symfony/messenger": "^4.3",


### PR DESCRIPTION
# Changed log
- Let this package require `php-7.2` version on `composer.json`.
- Add `php-7.4` version during Travis CI build.